### PR TITLE
Change beacon eviction logic.

### DIFF
--- a/luch/src/test/java/aga/android/luch/BeaconScannerTest.java
+++ b/luch/src/test/java/aga/android/luch/BeaconScannerTest.java
@@ -24,6 +24,14 @@ import static org.junit.Assert.assertEquals;
 @Config(sdk = 21, manifest = Config.NONE)
 public class BeaconScannerTest {
 
+    @Test(expected = AssertionError.class)
+    public void testNegativeBeaconValidityDurationIsNotAccepted() {
+        new BeaconScanner
+            .Builder()
+            .setBeaconExpirationDuration(-1)
+            .build();
+    }
+
     @Test
     public void testScannerStartsAndStopsScansViaBleDevice() {
         // given

--- a/sample/src/main/java/aga/android/luch/demo/data/BeaconLiveData.kt
+++ b/sample/src/main/java/aga/android/luch/demo/data/BeaconLiveData.kt
@@ -8,7 +8,6 @@ import aga.android.luch.ScanDuration
 import android.annotation.SuppressLint
 import android.os.Build
 import androidx.lifecycle.LiveData
-import java.util.concurrent.TimeUnit
 
 class BeaconLiveData : LiveData<Set<Beacon>>() {
 
@@ -17,7 +16,7 @@ class BeaconLiveData : LiveData<Set<Beacon>>() {
     }
 
     private val scanner: IScanner = BeaconScanner.Builder()
-        .setBeaconEvictionTime(TimeUnit.SECONDS.toMillis(10))
+        .setBeaconExpirationDuration(10)
         .setScanDuration(
             if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
                 ScanDuration.preciseDuration(150, 1500)


### PR DESCRIPTION
Run the eviction logic once in a second, use the builder parameter only to set the validity.