### PR TITLE
Execute Bluetooth scans and Beacon mapping on the background thread

### DIFF
--- a/luch/build.gradle
+++ b/luch/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
 
     testImplementation 'junit:junit:4.12'
+    testImplementation 'org.jmock:jmock-junit4:2.12.0'
     testImplementation 'org.robolectric:robolectric:4.1'
     testImplementation 'org.mockito:mockito-core:2.7.22'
 

--- a/luch/src/main/java/aga/android/luch/BeaconScanner.java
+++ b/luch/src/main/java/aga/android/luch/BeaconScanner.java
@@ -285,9 +285,7 @@ public class BeaconScanner implements IScanner {
 
             nearbyBeacons.put(beacon, elapsedRealtime());
 
-            if (beaconListener != null) {
-                beaconListener.onNearbyBeaconsDetected(nearbyBeacons.keySet());
-            }
+            uiHandler.post(deliverBeaconsJob);
         }
 
         @Override

--- a/luch/src/main/java/aga/android/luch/ScanExecutorProvider.java
+++ b/luch/src/main/java/aga/android/luch/ScanExecutorProvider.java
@@ -1,0 +1,8 @@
+package aga.android.luch;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+interface ScanExecutorProvider {
+
+    ScheduledExecutorService provide();
+}


### PR DESCRIPTION
Reasons:
1. Using Bluetooth functionality on the main thread use to lead to the UI thread freezes [in past](https://github.com/AltBeacon/android-beacon-library/issues/136) and I'm not sure whether it's still the case; better to be safe than sorry
2. By moving these ops onto the ScheduledExecutorService and replacing it with the DeterministicScheduler test we can rely on the virtual time instead of the real time which leads to better tests.