### PR TITLE
Do not check if BluetoothAdapter is enabled or not while stopping the scans.

### DIFF
--- a/luch/src/main/java/aga/android/luch/SystemBleDevice.java
+++ b/luch/src/main/java/aga/android/luch/SystemBleDevice.java
@@ -84,14 +84,6 @@ class SystemBleDevice implements IBleDevice {
     @Override
     public void stopScans(@NonNull ScanCallback scanCallback) {
         try {
-            if (!bluetoothAdapter.isEnabled()) {
-                BeaconLogger.e(
-                    "Can't stop the BLE scans since BluetoothAdapter is not enabled, most likely "
-                        + "the scans weren't started either (check if Bluetooth is turned on)"
-                );
-                return;
-            }
-
             final BluetoothLeScanner bleScanner = bluetoothAdapter.getBluetoothLeScanner();
 
             if (bleScanner == null) {


### PR DESCRIPTION
Otherwise, we might end up having a ScanCallback that keeps getting called by OS despite the fact that Bluetooth is off. The way to reproduce it is to wait until we're in the middle of the scan, then turn Bluetooth off and attempt to stop the scan via IScanner.stop().